### PR TITLE
fix bug to fetch stock meta

### DIFF
--- a/fooltrader/api/quote.py
+++ b/fooltrader/api/quote.py
@@ -73,7 +73,10 @@ def get_security_list(security_type='stock', exchanges=['sh', 'sz'], start=None,
                 if exchange == 'sh' or exchange == 'sz':
                     if mode == 'simple':
                         df1 = pd.read_csv(the_path,
-                                          converters={'code': str})
+                                          converters={'code': str,
+                                                      'sinaIndustry': convert_to_list_if_need,
+                                                      'sinaConcept': convert_to_list_if_need,
+                                                      'sinaArea': convert_to_list_if_need})
                     else:
                         df1 = pd.read_csv(the_path,
                                           converters={'code': str,
@@ -116,7 +119,8 @@ def get_security_list(security_type='stock', exchanges=['sh', 'sz'], start=None,
         if codes:
             df_usa = df_usa.loc[codes]
 
-    df = df.append(df_usa, ignore_index=True)
+        df = df.append(df_usa, ignore_index=True)
+        df = df.set_index(df['code'], drop=False)
     return df
 
 


### PR DESCRIPTION
在datamanger.crawl_stock_meta运行时，需要使用df.index进行匹配，但quote.py中的：
df = df.append(df_usa, ignore_index=True)会导致df重新以0,1,...作为索引。
另外，如果sinaIndustry等为空时pandas读入后会以float64类型进行处理，导致类型不匹配而无法对数据进行更新。